### PR TITLE
Reset jira status to 'TODO' to reuse existing TP.

### DIFF
--- a/corio.py
+++ b/corio.py
@@ -136,7 +136,7 @@ def main(options):
     collect_resource_utilisation(action="start")
     if jira_flg:
         jira_obj = JiraApp()
-        tests_details = jira_obj.get_all_tests_details_from_tp(options.test_plan)
+        tests_details = jira_obj.get_all_tests_details_from_tp(options.test_plan, reset_status=True)
     if os.path.isdir(options.test_input):
         file_list = glob.glob(options.test_input + "/*")
     elif os.path.isfile(options.test_input):

--- a/src/commons/utils/jira_utils.py
+++ b/src/commons/utils/jira_utils.py
@@ -34,6 +34,7 @@ from jira import JIRAError
 from requests.adapters import HTTPAdapter
 from requests.exceptions import RequestException
 from requests.packages.urllib3.util.retry import Retry
+
 from src.commons.constants import ROOT
 
 LOGGER = logging.getLogger(ROOT)
@@ -126,8 +127,7 @@ class JiraApp:
         "testIssues":{"success": [{"id":"328135","key":"TEST-19537",
         "self":"https://jts.seagate.com/rest/api/2/issue/328135"}]},"infoMessages":[]}
         """
-        state = {}
-        status = dict()
+        state, status = {}, {}
         state["testExecutionKey"] = test_exe_id
         status["testKey"] = test_id
         if test_status.upper() == 'EXECUTING':
@@ -174,13 +174,13 @@ class JiraApp:
             LOGGER.exception("Error code: %s, error test: %s", err.status_code, err.text)
             return err
 
-    def get_all_tests_details_from_tp(self, tp_id: str) -> dict:
+    def get_all_tests_details_from_tp(self, tp_id: str, reset_status: bool = False) -> dict:
         """
         Get all tests execution details from test plan.
 
         :param tp_id: ID of the test plan.
+        :param reset_status: Reset jira status to 'TODO' to reuse existing TP.
         :return: Dictionary of tests from test execution ticket.
-
         """
         tests_dict = {}
         te_details = self.get_te_details_from_test_plan(tp_id)
@@ -192,6 +192,13 @@ class JiraApp:
                                     f" TE '{texe['key']}'")
                 tests_dict[test['key']] = test
                 tests_dict[test['key']]["te"] = texe
+                if reset_status:
+                    # Reset jira test status to start new execution.
+                    if test["status"].upper() != "TODO":
+                        self.update_test_jira_status(test['te']['key'], test['key'], "TODO")
+                        LOGGER.debug("%s: status '%s' reset to '%s'", test['key'],
+                                     test['status'], 'TODO')
+                        test["status"] = "TODO"
         LOGGER.info(tests_dict)
 
         return tests_dict


### PR DESCRIPTION
Signed-off-by: Vishal Dhobale <vishal.dhobale@seagate.com>

# Problem Statement
-   Reset test status to TODO if we are using existing TP having FAIL/ABORTED/INPROGRESS tests.

# Design
-   For Bug, Describe the fix here.
-   For new test addition post the link for design

# Coding
   Checklist for Author
-   [x] Coding conventions are followed and code is formatted (e.g. using pycharm in-built formatter)

# Testing 
  Checklist for Author
-   [x] New/Affected tests are executed
-   [x] Attach test execution logs

# Review 
  Checklist for Author
-   [x] JIRA number/GitHub Issue added to PR
-   [x] PR is self reviewed
-   [x] Jira and state/status is updated and JIRA is updated with PR link
-   [x] Check if the description is clear and explained

# Documentation 
  Checklist for Author
-   [ ] Changes done to ReadMe
