### PR TITLE
object size distribution in percentage

### DIFF
--- a/docs/YAML_documents/yaml_structure.md
+++ b/docs/YAML_documents/yaml_structure.md
@@ -71,6 +71,8 @@ calculated.
 **operation** should be specified according to type of workload and need to map it in corio.py with
 appropriate test script.
 
+**total_samples** Total number of samples given by user to define object size distribution.
+
 ---
 
 Sample YAML file can be found at [sample file](sample_file.yaml)


### PR DESCRIPTION
Signed-off-by: akshaym99 <akshay.s.mankar@seagate.com>

## Problem Statement

-   Support to accept object size distribution given in percentage, samples will be given on total samples.

## Design

-   For Bug, Describe the fix here.
-   Input yaml example: `test_1:
    TEST_ID: TEST-40039
    object_size:
      0Kb: 2%
      1Kb: 24.79%
      10Kb: 18.84%
      100Kb: 17.87%
      1Mb: 18.2%
      10Mb: 16.7%
      100Mb: 1.56%
      1Gb: 0.03%
      2Gb: 0.01%
    total_samples: 10000` 
ouput data dictionary: `{'TEST_ID': 'TEST-37228', 'object_size': {0: 200, 1000: 2479, 10000: 1884, 100000: 1787, 1000000: 1820, 10000000: 1670, 100000000: 156, 1000000000: 3, 2000000000: 1}, 'total_samples': 10000}`

## Coding

   Checklist for Author

-   [ ]  Coding conventions are followed and code is formatted (e.g. using pycharm in-built formatter)

## Testing

  Checklist for Author

-   [ ]  New/Affected tests are executed
-   [ ]  Attach test execution logs

## Review 

  Checklist for Author

-   [x]  JIRA number/GitHub Issue added to PR
-   [x]  PR is self reviewed
-   [x]  Jira and state/status is updated and JIRA is updated with PR link
-   [ ]  Check if the description is clear and explained

## Documentation

  Checklist for Author

-   [ ]  Changes done to ReadMe
