### PR TITLE
Configurable s3 chunk_size parameter for read/checksum of object

### DIFF
--- a/config/s3/s3_config.yaml
+++ b/config/s3/s3_config.yaml
@@ -16,3 +16,5 @@ retry_delay: 2 # in seconds.
 connect_timeout: 300
 # The time in seconds till a timeout exception is thrown when attempting to read from a connection.
 read_timeout: 300
+# This is used for get, download object api and calculate file checksum. default is 4Mib
+chunk_size: 4194304


### PR DESCRIPTION
## Problem Statement

- As per request on bug https://jts.seagate.com/browse/CORTX-33747 to make get_object chunk size configurable.

## Design

-   For Bug, Describe the fix here: Added configurable chunk_size parameter so that it can be used for get object and checksum operation and same can be changed as per requirement.
-   For new test addition post the link for design

## Coding

   Checklist for Author

-   [x]  Coding conventions are followed and code is formatted (e.g. using pycharm in-built formatter)

## Testing

  Checklist for Author

-   [x]  New/Affected tests are executed
-   [x]  Attach test execution logs: https://jts.seagate.com/secure/attachment/535860/CORTX-22404-SanityRun_for_chunk_size_configurable_changes.zip

## Review 

  Checklist for Author

-   [x]  JIRA number/GitHub Issue added to PR
-   [x]  PR is self reviewed
-   [x]  Jira and state/status is updated and JIRA is updated with PR link
-   [x]  Check if the description is clear and explained

## Documentation

  Checklist for Author

-   [x]  Changes done to ReadMe
